### PR TITLE
Update WebClient.cs

### DIFF
--- a/LyricsReloaded/WebClient.cs
+++ b/LyricsReloaded/WebClient.cs
@@ -32,7 +32,7 @@ namespace CubeIsland.LyricsReloaded
 {
     public class WebClient
     {
-        private static readonly Regex ENCODING_REGEX = new Regex("<meta\\s+http-equiv=[\"']?content-type[\"']?\\s+content=.*?;\\s*charset\\s*=\\s*([a-z0-9-]+)[^>]*>|<\\?xml.+?encoding=\"([^\"]).*?\\?>", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex ENCODING_REGEX = new Regex("<meta\\s+http-equiv=[\"']?content-type[\"']?\\s+content=.*?;\\s*charset\\s*=\\s*([a-z0-9-]+)[^>]*>|<\\?xml.+?encoding=\"([^\"]).*?\\?>|<meta\\s*data-react-helmet=\"true\"\\s*charset=\"([^\"]*?)\"", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private readonly LyricsReloaded lyricsReloaded;
         private readonly int timeout;


### PR DESCRIPTION
I believe I found the cause of the Musixmatch provider saying "lyrics found" but then returning an empty result. You referenced it in this thread: https://getmusicbee.com/forum/index.php?topic=25406.msg185630#msg185630

It seems Musixmatch is not including any of the normal character set information in the header, and so the ENCODING_REGEX match is failing. I think leads to an uncaught error on line 259.

I added a pattern to the end of ENCODING_REGEX intended to match data-react-helmet charset used on Musixmatch. I do not currently have the ability to compile and test this change, but I hope this suggestion is helpful.